### PR TITLE
Removed cuddlybuddly from namespace packages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,6 @@ setup(
 
     package_dir = {'': 'src'},
     packages = find_packages('src'),
-    namespace_packages = ['cuddlybuddly'],
     include_package_data = True,
     zip_safe = False,
 


### PR DESCRIPTION
With cuddlybuddly in the namespace packages when this app is installed by pip the **init**.py is not copied to the correct place so the django apps can not recognise it . 
